### PR TITLE
fix/download

### DIFF
--- a/projects/docs/src/modules/home/components/download/download.tsx
+++ b/projects/docs/src/modules/home/components/download/download.tsx
@@ -14,7 +14,6 @@ export const Download = component$(() => {
         <Button.Group variant="inline" class={Styles.buttons}>
           <Button
             href="https://github.com/Minnek-Digital-Studio/cominnek/releases/latest/download/cominnek-4.0.0.dmg"
-            _target="_blank"
             variant="dark"
             class={Styles.button}
             title="MacOS"
@@ -23,7 +22,6 @@ export const Download = component$(() => {
           </Button>
           <Button
             href="https://github.com/Minnek-Digital-Studio/cominnek/releases/latest/download/cominnek-4.0.0.exe"
-            _target="_blank"
             variant="dark"
             class={Styles.button}
             title="Windows"

--- a/projects/docs/src/modules/home/components/download/download.tsx
+++ b/projects/docs/src/modules/home/components/download/download.tsx
@@ -30,7 +30,6 @@ export const Download = component$(() => {
           </Button>
           <Button
             href="https://github.com/Minnek-Digital-Studio/cominnek/releases/latest/download/cominnek-4.0.0.deb"
-            _target="_blank"
             variant="dark"
             class={Styles.button}
             title="Linux"


### PR DESCRIPTION
## Issue Info

When you click on any of the buttons to download, it sends you to a blank page that downloads. When you accept, it returns to the main page and downloads again. By duplicating the downloads, to solve this it is proposed to eliminate the jump to a blank page.

